### PR TITLE
Add chess animations

### DIFF
--- a/frontend/src/components/ChessBoard.tsx
+++ b/frontend/src/components/ChessBoard.tsx
@@ -1,25 +1,62 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Chess } from 'chess.js';
 import ChessPiece from './ChessPieces';
+
+interface LastMove {
+  from: string;
+  to: string;
+  color: 'w' | 'b';
+  piece: string;
+  captured?: string;
+}
 
 interface ChessBoardProps {
   game: Chess;
   isGameStarted: boolean;
+  lastMove: LastMove | null;
 }
+const SQUARE_SIZE = 70;
 
-const ChessBoard: React.FC<ChessBoardProps> = ({ game, isGameStarted }) => {
+const ChessBoard: React.FC<ChessBoardProps> = ({ game, isGameStarted, lastMove }) => {
   const board = game.board();
+  const [animateMove, setAnimateMove] = useState(false);
+  const [currentMove, setCurrentMove] = useState<LastMove | null>(null);
+
+  useEffect(() => {
+    if (lastMove) {
+      setCurrentMove(lastMove);
+      setAnimateMove(false);
+      requestAnimationFrame(() => setAnimateMove(true));
+    }
+  }, [lastMove]);
+
+  const squareToCoords = (sq: string) => {
+    const file = sq.charCodeAt(0) - 97;
+    const rank = 8 - parseInt(sq[1], 10);
+    return { row: rank, col: file };
+  };
 
   const renderSquare = (piece: any, row: number, col: number) => {
     const isLightSquare = (row + col) % 2 === 0;
     const squareColor = isLightSquare ? '#f0d9b5' : '#b58863';
-    
+    const square = `${String.fromCharCode(97 + col)}${8 - row}`;
+    const isMovingPiece = currentMove && currentMove.to === square;
+
+    let pieceStyle: React.CSSProperties = {};
+    if (isMovingPiece && currentMove) {
+      const from = squareToCoords(currentMove.from);
+      const offsetX = (from.col - col) * SQUARE_SIZE;
+      const offsetY = (from.row - row) * SQUARE_SIZE;
+      pieceStyle.transform = animateMove ? 'translate(0, 0)' : `translate(${offsetX}px, ${offsetY}px)`;
+      pieceStyle.transition = 'transform 0.3s ease';
+    }
+
     return (
       <div
         key={`${row}-${col}`}
         style={{
-          width: '70px',
-          height: '70px',
+          width: `${SQUARE_SIZE}px`,
+          height: `${SQUARE_SIZE}px`,
           backgroundColor: squareColor,
           display: 'flex',
           alignItems: 'center',
@@ -30,11 +67,35 @@ const ChessBoard: React.FC<ChessBoardProps> = ({ game, isGameStarted }) => {
         }}
       >
         {piece && (
-          <ChessPiece
-            piece={piece.type}
-            color={piece.color === 'w' ? 'white' : 'black'}
-            size={50}
-          />
+          <div style={pieceStyle}>
+            <ChessPiece
+              piece={piece.type}
+              color={piece.color === 'w' ? 'white' : 'black'}
+              size={50}
+            />
+          </div>
+        )}
+        {isMovingPiece && currentMove?.captured && !animateMove && (
+          <div
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              animation: 'fadeOut 0.3s forwards',
+              pointerEvents: 'none'
+            }}
+          >
+            <ChessPiece
+              piece={currentMove.captured}
+              color={currentMove.color === 'w' ? 'black' : 'white'}
+              size={50}
+            />
+          </div>
         )}
         <span style={{
           position: 'absolute',
@@ -54,8 +115,8 @@ const ChessBoard: React.FC<ChessBoardProps> = ({ game, isGameStarted }) => {
   return (
     <div style={{
       display: 'grid',
-      gridTemplateColumns: 'repeat(8, 70px)',
-      gridTemplateRows: 'repeat(8, 70px)',
+      gridTemplateColumns: `repeat(8, ${SQUARE_SIZE}px)`,
+      gridTemplateRows: `repeat(8, ${SQUARE_SIZE}px)`,
       border: '3px solid #8b4513',
       backgroundColor: '#fff',
       borderRadius: '8px',

--- a/frontend/src/components/ChessGame.tsx
+++ b/frontend/src/components/ChessGame.tsx
@@ -39,6 +39,13 @@ interface GameState {
   thinkingOutput: string;
   isStreaming: boolean;
   errorMessage: string | null;
+  lastMove: {
+    from: string;
+    to: string;
+    color: 'w' | 'b';
+    piece: string;
+    captured?: string;
+  } | null;
 }
 
 const formatTime = (milliseconds: number): string => {
@@ -73,7 +80,8 @@ const ChessGame: React.FC = () => {
     awaitingDrawResponse: false,
     thinkingOutput: '',
     isStreaming: false,
-    errorMessage: null
+    errorMessage: null,
+    lastMove: null
   });
 
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -267,18 +275,25 @@ const ChessGame: React.FC = () => {
                             const updatedThinkingTokens = [...prevState.moveThinkingTokens, data.thinking_tokens || 0];
                             const updatedMoveTimes = [...prevState.moveTimes, moveTime];
 
-                            return {
-                              ...prevState,
-                              game: newGame,
-                              currentPlayer: prevState.currentPlayer === 'white' ? 'black' : 'white',
-                              isGameOver,
-                              gameResult,
-                              isThinking: false,
-                              isStreaming: false,
-                              capturedPieces: updatedCapturedPieces,
-                              moveThinkingTokens: updatedThinkingTokens,
-                              moveTimes: updatedMoveTimes
-                            };
+                              return {
+                                ...prevState,
+                                game: newGame,
+                                currentPlayer: prevState.currentPlayer === 'white' ? 'black' : 'white',
+                                isGameOver,
+                                gameResult,
+                                isThinking: false,
+                                isStreaming: false,
+                                capturedPieces: updatedCapturedPieces,
+                                moveThinkingTokens: updatedThinkingTokens,
+                                moveTimes: updatedMoveTimes,
+                                lastMove: {
+                                  from: move.from,
+                                  to: move.to,
+                                  color: move.color as 'w' | 'b',
+                                  piece: move.piece,
+                                  captured: move.captured
+                                }
+                              };
                           } else {
                             if (IS_DEBUG) console.error('Invalid move returned:', data.move);
                             return { ...prevState, isThinking: false, isStreaming: false };
@@ -528,7 +543,8 @@ const ChessGame: React.FC = () => {
       awaitingDrawResponse: false,
       thinkingOutput: '',
       isStreaming: false,
-      errorMessage: null
+      errorMessage: null,
+      lastMove: null
     });
   };
 
@@ -751,10 +767,11 @@ const ChessGame: React.FC = () => {
             capturedBy="black"
           />
           
-          <ChessBoard 
-            game={gameState.game}
-            isGameStarted={gameState.isGameStarted}
-          />
+            <ChessBoard
+              game={gameState.game}
+              isGameStarted={gameState.isGameStarted}
+              lastMove={gameState.lastMove}
+            />
           
           <CapturedPiecesRow 
             pieces={gameState.capturedPieces.white} 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,12 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- animate piece moves and captures in the board
- track the last move in game state for animations
- add fadeOut animation CSS

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684816457934832584f5b462fe74e974